### PR TITLE
[make]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# make
+
+Make is a tool which controls the generation of executables and other non-source files of a program from the program's source files.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.make?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # make
 
 Make is a tool which controls the generation of executables and other non-source files of a program from the program's source files.

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,1 @@
-command_path: '/bin/make'
+command_relative_path: '/bin/make'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_path: '/bin/make'

--- a/config/fixtures/Makefile
+++ b/config/fixtures/Makefile
@@ -1,0 +1,2 @@
+ci-test:
+	@echo "Make in CI"

--- a/controls/make_exists.rb
+++ b/controls/make_exists.rb
@@ -2,9 +2,6 @@ title 'Tests to confirm make exists'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'make')
-plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
-command_relative_path = input('command_relative_path', value: '/bin/make')
-command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
 
 control 'core-plans-make-exists' do
   impact 1.0
@@ -12,11 +9,14 @@ control 'core-plans-make-exists' do
   desc '
   Verify make by ensuring /bin/make exists'
   
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
 
+  command_relative_path = input('command_relative_path', value: '/bin/make')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
   describe file(command_full_path) do
     it { should exist }
   end

--- a/controls/make_exists.rb
+++ b/controls/make_exists.rb
@@ -1,0 +1,17 @@
+title 'Tests to confirm make exists'
+
+plan_name = input('plan_name', value: 'make')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+make_relative_path = input('command_path', value: '/bin/make')
+make_installation_directory = command("hab pkg path #{plan_ident}")
+make_full_path = make_installation_directory.stdout.strip + "#{ make_relative_path}"
+ 
+control 'core-plans-make-exists' do
+  impact 1.0
+  title 'binary should exist'
+  desc '
+  '
+   describe file(make_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/make_exists.rb
+++ b/controls/make_exists.rb
@@ -1,17 +1,23 @@
 title 'Tests to confirm make exists'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'make')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
-make_relative_path = input('command_path', value: '/bin/make')
-make_installation_directory = command("hab pkg path #{plan_ident}")
-make_full_path = make_installation_directory.stdout.strip + "#{ make_relative_path}"
- 
+plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+command_relative_path = input('command_relative_path', value: '/bin/make')
+command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+
 control 'core-plans-make-exists' do
   impact 1.0
-  title 'binary should exist'
+  title 'Ensure make exists'
   desc '
-  '
-   describe file(make_full_path) do
+  Verify make by ensuring /bin/make exists'
+  
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  describe file(command_full_path) do
     it { should exist }
   end
 end

--- a/controls/make_works.rb
+++ b/controls/make_works.rb
@@ -1,0 +1,43 @@
+title 'Tests to confirm make works as expected'
+
+plan_name = input('plan_name', value: 'make')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+make_path = command("hab pkg path #{plan_ident}")
+make_pkg_ident = ((make_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+
+control 'core-plans-make-works-001' do
+  impact 1.0
+  title 'should be installed'
+  desc '
+  '
+  describe make_path do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+end
+
+control 'core-plans-make-works-002' do
+  impact 1.0
+  title 'should be at correct version'
+  desc '
+  '
+  describe command("DEBUG=true; hab pkg exec #{make_pkg_ident} make --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /GNU Make 4.2.1/ }
+    its('stderr') { should be_empty }
+  end
+end
+
+control 'core-plans-make-works-003' do
+  impact 1.0
+  title 'should act on a Makefile'
+  desc '
+  '
+  describe command("DEBUG=true; hab pkg exec #{make_pkg_ident} make --directory /hab/svc/make/config/fixtures/ ci-test") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /Make in CI/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/make_works.rb
+++ b/controls/make_works.rb
@@ -1,40 +1,32 @@
 title 'Tests to confirm make works as expected'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'make')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
-make_path = command("hab pkg path #{plan_ident}")
-make_pkg_ident = ((make_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
 
-control 'core-plans-make-works-001' do
+control 'core-plans-make-works' do
   impact 1.0
-  title 'should be installed'
+  title 'Ensure make works as expected'
   desc '
+  Verify make by ensuring (1) its installation directory exists; (2) that
+  it returns the expected version; (3) it runs successfully against a sample Makefile
   '
-  describe make_path do
+  
+  describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
-end
-
-control 'core-plans-make-works-002' do
-  impact 1.0
-  title 'should be at correct version'
-  desc '
-  '
-  describe command("DEBUG=true; hab pkg exec #{make_pkg_ident} make --version") do
+  
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} make --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stdout') { should match /GNU Make 4.2.1/ }
+    its('stdout') { should match /GNU Make #{plan_pkg_version}/ }
     its('stderr') { should be_empty }
   end
-end
 
-control 'core-plans-make-works-003' do
-  impact 1.0
-  title 'should act on a Makefile'
-  desc '
-  '
-  describe command("DEBUG=true; hab pkg exec #{make_pkg_ident} make --directory /hab/svc/make/config/fixtures/ ci-test") do
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} make --directory /hab/svc/make/config/fixtures/ ci-test") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /Make in CI/ }

--- a/controls/make_works.rb
+++ b/controls/make_works.rb
@@ -2,9 +2,6 @@ title 'Tests to confirm make works as expected'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'make')
-plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
-plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
 
 control 'core-plans-make-works' do
   impact 1.0
@@ -14,11 +11,14 @@ control 'core-plans-make-works' do
   it returns the expected version; (3) it runs successfully against a sample Makefile
   '
   
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
   
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
   describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} make --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: make
+title: Habitat Core Plan make
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan make
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/no-sys-dirs.patch
+++ b/no-sys-dirs.patch
@@ -1,0 +1,59 @@
+Thanks to: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/build-managers/gnumake/4.1/impure-dirs.patch
+
+diff -ur make-4.1.orig/read.c make-4.1/read.c
+--- make-4.1.orig/read.c        2014-10-05 16:24:51.000000000 +0000
++++ make-4.1/read.c     2016-01-19 20:51:24.082059349 +0000
+@@ -110,10 +110,12 @@
+ #endif
+     INCLUDEDIR,
+ #ifndef _AMIGA
++#if 0
+     "/usr/gnu/include",
+     "/usr/local/include",
+     "/usr/include",
+ #endif
++#endif
+     0
+   };
+
+diff -ur make-4.1.orig/remake.c make-4.1/remake.c
+--- make-4.1.orig/remake.c      2014-10-05 16:24:51.000000000 +0000
++++ make-4.1/remake.c   2016-01-19 20:51:24.082059349 +0000
+@@ -1549,9 +1549,11 @@
+   static const char *dirs[] =
+     {
+ #ifndef _AMIGA
++#if 0
+       "/lib",
+       "/usr/lib",
+ #endif
++#endif
+ #if defined(WINDOWS32) && !defined(LIBDIR)
+ /*
+  * This is completely up to the user at product install time. Just define
+diff -ur make-4.1.orig/tests/scripts/misc/fopen-fail make-4.1/tests/scripts/misc/fopen-fail
+--- make-4.1.orig/tests/scripts/misc/fopen-fail 2014-10-05 16:24:51.000000000 +0000
++++ make-4.1/tests/scripts/misc/fopen-fail      2016-01-19 20:52:05.613561453 +0000
+@@ -2,6 +2,9 @@
+
+ $description = "Make sure make exits with an error if fopen fails.";
+
++# Not going to bother with this test, esp. if it exhausts open file handles
++return -1;
++
+ # Recurse infinitely until we run out of open files, and ensure we
+ # fail with a non-zero exit code.  Don't bother to test the output
+ # since it's hard to know what it will be, exactly.
+diff -ur make-4.1.orig/tests/scripts/variables/INCLUDE_DIRS make-4.1/tests/scripts/variables/INCLUDE_DIRS
+--- make-4.1.orig/tests/scripts/variables/INCLUDE_DIRS  2014-10-05 16:24:51.000000000 +0000
++++ make-4.1/tests/scripts/variables/INCLUDE_DIRS       2016-01-19 20:51:24.082059349 +0000
+@@ -8,6 +8,9 @@
+ $dir = cwd;
+ $dir =~ s,.*/([^/]+)$,../$1,;
+
++# We want .INCLUDE_DIRS to be empty
++return -1;
++
+ # Test #1: The content of .INCLUDE_DIRS depends on the platform for which
+ #          make was built. What we know for sure is that it shouldn't be
+ #          empty.

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,78 @@
+# Disable shellcheck that would require quotes around pkg_name
+# shellcheck disable=SC2209
+pkg_name=make
+pkg_origin=core
+pkg_version=4.2.1
+pkg_description="\
+Make is a tool which controls the generation of executables and other \
+non-source files of a program from the program's source files.\
+"
+pkg_upstream_url="https://www.gnu.org/software/make/"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('GPL-3.0-or-later')
+pkg_source="http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.bz2"
+pkg_shasum="d6e262bf3601b42d2b1e4ef8310029e1dcf20083c5446b4b7aa67081fdffc589"
+pkg_deps=(
+  core/glibc
+)
+pkg_build_deps=(
+  core/patch
+  core/make
+  core/gcc
+  core/perl
+  core/binutils
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+
+do_prepare() {
+  do_default_prepare
+
+  # Don't look for library dependencies in the root system (i.e. `/lib`,
+  # `/usr/lib`, etc.)
+  patch -p1 -i "$PLAN_CONTEXT/no-sys-dirs.patch"
+
+  # Work around an error caused by Glibc 2.27
+  #
+  # Thanks to: http://www.linuxfromscratch.org/lfs/view/8.2/chapter05/make.html
+  sed -i '211,217 d; 219,229 d; 232 d' glob/glob.c
+}
+
+do_check() {
+  # Force `ar` to not run in deterministic mode, as the testsuite relies on
+  # UID, GID, timestamp and file mode values to be correctly stored.
+  #
+  # Thanks to: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=782750
+  mkdir -pv wrappers
+  cat <<EOF > wrappers/ar
+#!/bin/sh
+exec $(pkg_path_for binutils)/bin/ar U\$@
+EOF
+  chmod -v 0744 wrappers/ar
+
+  # The `PERL_USE_UNSAFE_INC=1` variable allows the test suite to run with Perl
+  # 5.26 (resolves a "Can't locate driver" error).
+  #
+  # Thanks to:
+  # * https://lists.gnu.org/archive/html/bug-make/2017-03/msg00040.html
+  # * https://bugs.archlinux.org/task/55127
+  env PATH="$(pwd)/wrappers:$PATH" PERL_USE_UNSAFE_INC=1 make check
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/binutils
+    core/gcc
+    core/sed
+    core/bash
+    core/perl
+  )
+fi

--- a/tests/fixtures/Makefile
+++ b/tests/fixtures/Makefile
@@ -1,0 +1,2 @@
+ci-test:
+	@echo "Make in CI"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,10 @@
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "make matches version ${expected_version}" {
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" make --version | grep "GNU Make" | awk '{print $3}')"
+  diff <( echo "$actual_version" ) <( echo "${expected_version}" )
+}
+
+@test "Make simple task" {
+  run hab pkg exec "$TEST_PKG_IDENT" make --directory "$BATS_TEST_DIRNAME/fixtures/" ci-test
+  grep -q "Make in CI" <<< "$output"
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://2f6879f8bc5227660684d0f7239c8c61326255b22d824ba8d4088e406d20d9f8 --input-file /src/attributes.yml

Profile: Habitat Core Plan make (make)
Version: 0.1.0
Target:  docker://2f6879f8bc5227660684d0f7239c8c61326255b22d824ba8d4088e406d20d9f8

  ✔  core-plans-make-works-001: should be installed
     ✔  Command: `hab pkg path core/make` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/make` stdout is expected not to be empty
  ✔  core-plans-make-works-002: should be at correct version
     ✔  Command: `DEBUG=true; hab pkg exec core/make/4.2.1/20200603172433 make --version` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/make/4.2.1/20200603172433 make --version` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/make/4.2.1/20200603172433 make --version` stdout is expected to match /GNU Make 4.2.1/
     ✔  Command: `DEBUG=true; hab pkg exec core/make/4.2.1/20200603172433 make --version` stderr is expected to be empty
  ✔  core-plans-make-works-003: should act on a Makefile
     ✔  Command: `DEBUG=true; hab pkg exec core/make/4.2.1/20200603172433 make --directory /hab/svc/make/config/fixtures/ ci-test` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/make/4.2.1/20200603172433 make --directory /hab/svc/make/config/fixtures/ ci-test` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/make/4.2.1/20200603172433 make --directory /hab/svc/make/config/fixtures/ ci-test` stdout is expected to match /Make in CI/
     ✔  Command: `DEBUG=true; hab pkg exec core/make/4.2.1/20200603172433 make --directory /hab/svc/make/config/fixtures/ ci-test` stderr is expected to be empty
  ✔  core-plans-make-exists: binary should exist
     ✔  File /hab/pkgs/core/make/4.2.1/20200603172433/bin/make is expected to exist


Profile Summary: 4 successful controls, 0 control failures, 0 controls skipped
Test Summary: 11 successful, 0 failures, 0 skipped
+ set +x
[9][default:/src:0]# 
```